### PR TITLE
Move from deprecated set-output

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,4 +6,4 @@ TBD
 
 ## Checklist
 
-- [] I tested the changes
+- [ ] I tested the changes

--- a/src/terragrunt_fmt.sh
+++ b/src/terragrunt_fmt.sh
@@ -67,12 +67,12 @@ ${fmtComment}
   fi
 
   # Write changes to branch
-  echo "::set-output name=tf_actions_fmt_written::false"
+  echo "tf_actions_fmt_written=false" >> $GITHUB_OUTPUT
   if [ "${tfFmtWrite}" == "1" ]; then
     echo "fmt: info: Terraform files in ${tfWorkingDir} will be formatted"
     terraform fmt -write=true ${fmtRecursive} "${*}"
     fmtExitCode=${?}
-    echo "::set-output name=tf_actions_fmt_written::true"
+    echo "tf_actions_fmt_written=true" >> $GITHUB_OUTPUT
   fi
 
   exit ${fmtExitCode}

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -17,7 +17,7 @@ function terragruntOutput {
     outputOutput="${outputOutput//$'\n'/'%0A'}"
     outputOutput="${outputOutput//$'\r'/'%0D'}"
 
-    echo "::set-output name=tf_actions_output::${outputOutput}"
+    echo "tf_actions_output=${outputOutput}" >> $GITHUB_OUTPUT
     exit ${outputExitCode}
   fi
 

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -17,7 +17,9 @@ function terragruntOutput {
     # outputOutput="${outputOutput//$'\n'/'%0A'}"
     # outputOutput="${outputOutput//$'\r'/'%0D'}"
 
-    echo "tf_actions_output=${outputOutput}" >> $GITHUB_OUTPUT
+    echo "tf_actions_output=<<EOF" >> $GITHUB_OUTPUT
+    echo "${outputOutput}" >> $GITHUB_OUTPUT
+    echo "EOF" >> $GITHUB_OUTPUT
     exit ${outputExitCode}
   fi
 

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -13,9 +13,9 @@ function terragruntOutput {
     echo
 
     # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-    outputOutput="${outputOutput//'%'/'%25'}"
-    outputOutput="${outputOutput//$'\n'/'%0A'}"
-    outputOutput="${outputOutput//$'\r'/'%0D'}"
+    # outputOutput="${outputOutput//'%'/'%25'}"
+    # outputOutput="${outputOutput//$'\n'/'%0A'}"
+    # outputOutput="${outputOutput//$'\r'/'%0D'}"
 
     echo "tf_actions_output=${outputOutput}" >> $GITHUB_OUTPUT
     exit ${outputExitCode}

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -12,11 +12,6 @@ function terragruntOutput {
     echo "${outputOutput}"
     echo
 
-    # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-    # outputOutput="${outputOutput//'%'/'%25'}"
-    # outputOutput="${outputOutput//$'\n'/'%0A'}"
-    # outputOutput="${outputOutput//$'\r'/'%0D'}"
-
     echo "tf_actions_output<<EOF" >> $GITHUB_OUTPUT
     echo "${outputOutput}" >> $GITHUB_OUTPUT
     echo "EOF" >> $GITHUB_OUTPUT

--- a/src/terragrunt_output.sh
+++ b/src/terragrunt_output.sh
@@ -17,7 +17,7 @@ function terragruntOutput {
     # outputOutput="${outputOutput//$'\n'/'%0A'}"
     # outputOutput="${outputOutput//$'\r'/'%0D'}"
 
-    echo "tf_actions_output=<<EOF" >> $GITHUB_OUTPUT
+    echo "tf_actions_output<<EOF" >> $GITHUB_OUTPUT
     echo "${outputOutput}" >> $GITHUB_OUTPUT
     echo "EOF" >> $GITHUB_OUTPUT
     exit ${outputExitCode}

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -13,7 +13,7 @@ function terragruntPlan {
     echo "plan: info: successfully planned Terragrunt configuration in ${tfWorkingDir}"
     echo "${planOutput}"
     echo
-    echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+    echo "tf_actions_plan_has_changes=${planHasChanges}" >> $GITHUB_OUTPUT
     exit ${planExitCode}
   fi
 
@@ -63,13 +63,13 @@ ${planOutput}
     echo "${planPayload}" | curl -s -S -H "Authorization: token ${GITHUB_TOKEN}" --header "Content-Type: application/json" --data @- "${planCommentsURL}" > /dev/null
   fi
 
-  echo ::set-output name=tf_actions_plan_has_changes::${planHasChanges}
+  echo "tf_actions_plan_has_changes=${planHasChanges}" >> $GITHUB_OUTPUT
 
   # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
   planOutput="${planOutput//'%'/'%25'}"
   planOutput="${planOutput//$'\n'/'%0A'}"
   planOutput="${planOutput//$'\r'/'%0D'}"
 
-  echo "::set-output name=tf_actions_plan_output::${planOutput}"
+  echo "tf_actions_plan_output=${planOutput}" >> $GITHUB_OUTPUT
   exit ${planExitCode}
 }

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -65,11 +65,6 @@ ${planOutput}
 
   echo "tf_actions_plan_has_changes=${planHasChanges}" >> $GITHUB_OUTPUT
 
-  # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-  # planOutput="${planOutput//'%'/'%25'}"
-  # planOutput="${planOutput//$'\n'/'%0A'}"
-  # planOutput="${planOutput//$'\r'/'%0D'}"
-
   echo "tf_actions_plan_output<<EOF" >> $GITHUB_OUTPUT
   echo "${planOutput}" >> $GITHUB_OUTPUT
   echo "EOF" >> $GITHUB_OUTPUT

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -70,6 +70,8 @@ ${planOutput}
   # planOutput="${planOutput//$'\n'/'%0A'}"
   # planOutput="${planOutput//$'\r'/'%0D'}"
 
-  echo "tf_actions_plan_output=${planOutput}" >> $GITHUB_OUTPUT
+  echo "tf_actions_plan_output<<EOF" >> $GITHUB_OUTPUT
+  echo "${planOutput}" >> $GITHUB_OUTPUT
+  echo "EOF" >> $GITHUB_OUTPUT
   exit ${planExitCode}
 }

--- a/src/terragrunt_plan.sh
+++ b/src/terragrunt_plan.sh
@@ -66,9 +66,9 @@ ${planOutput}
   echo "tf_actions_plan_has_changes=${planHasChanges}" >> $GITHUB_OUTPUT
 
   # https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/m-p/38372/highlight/true#M3322
-  planOutput="${planOutput//'%'/'%25'}"
-  planOutput="${planOutput//$'\n'/'%0A'}"
-  planOutput="${planOutput//$'\r'/'%0D'}"
+  # planOutput="${planOutput//'%'/'%25'}"
+  # planOutput="${planOutput//$'\n'/'%0A'}"
+  # planOutput="${planOutput//$'\r'/'%0D'}"
 
   echo "tf_actions_plan_output=${planOutput}" >> $GITHUB_OUTPUT
   exit ${planExitCode}


### PR DESCRIPTION
# Task: https://ask-ai.monday.com/boards/1750207014/pulses/3555836413
## PR Description

Move from the deprecated `set-output` to the new format. [Docs](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## Checklist

- [x] I tested the changes
